### PR TITLE
Add time/temp example

### DIFF
--- a/README
+++ b/README
@@ -15,3 +15,5 @@
   (RTC) with an integrated temperature-compensated crystal oscillator 
   (TCXO) and crystal.
 
+
+Example sketches are provided in the examples directory. `rtc_ds3231_time_temp` shows how to print the current time along with the temperature every five seconds.

--- a/examples/rtc_ds3231_time_temp/Makefile
+++ b/examples/rtc_ds3231_time_temp/Makefile
@@ -1,0 +1,12 @@
+
+# Board settings.
+#BOARD = atmega328
+#BOARD = pro5v328
+
+MON_SPEED = 9600
+
+# Where to find header files and libraries.
+LIB_DIRS = ../../ /local/arduino-100/libraries/Wire/ /local/arduino-100/libraries/Wire/utility/
+
+include ../../../Makefile.master
+

--- a/examples/rtc_ds3231_time_temp/rtc_ds3231_time_temp.ino
+++ b/examples/rtc_ds3231_time_temp/rtc_ds3231_time_temp.ino
@@ -1,0 +1,24 @@
+#include <Wire.h>
+#include "ds3231.h"
+
+#define BUFF_MAX 128
+
+void setup()
+{
+    Serial.begin(9600);
+    Wire.begin();
+    DS3231_init(DS3231_INTCN);
+}
+
+void loop()
+{
+    char buff[BUFF_MAX];
+    struct ts t;
+    DS3231_get(&t);
+    float temp = DS3231_get_treg();
+
+    snprintf(buff, BUFF_MAX, "%d.%02d.%02d %02d:%02d:%02d  %.2fC",
+             t.year, t.mon, t.mday, t.hour, t.min, t.sec, temp);
+    Serial.println(buff);
+    delay(5000);
+}


### PR DESCRIPTION
## Summary
- add minimal sketch `rtc_ds3231_time_temp` showing time and temperature readings
- document example in `README`

## Testing
- `make -C examples/rtc_ds3231_time_temp` *(fails: `Makefile:11: ../../../Makefile.master: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6842f913ff70832a8166d9675abb64d4